### PR TITLE
feat: add user-level preferences config file

### DIFF
--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// User-level preferences stored at `~/.config/kaiten-mcp/preferences.json`
+/// (Linux) or `~/Library/Application Support/kaiten-mcp/preferences.json` (macOS).
+struct Preferences: Codable, Sendable {
+    var mySpaces: [SpaceRef]?
+    var myBoards: [BoardRef]?
+
+    struct SpaceRef: Codable, Sendable {
+        let id: Int
+        var alias: String?
+    }
+
+    struct BoardRef: Codable, Sendable {
+        let id: Int
+        var alias: String?
+    }
+
+    /// Board IDs from preferences, or `nil` if not configured.
+    var boardIds: [Int]? {
+        guard let boards = myBoards, !boards.isEmpty else { return nil }
+        return boards.map(\.id)
+    }
+
+    /// Space IDs from preferences, or `nil` if not configured.
+    var spaceIds: [Int]? {
+        guard let spaces = mySpaces, !spaces.isEmpty else { return nil }
+        return spaces.map(\.id)
+    }
+
+    // MARK: - File path
+
+    /// Platform-appropriate config directory.
+    static var configDirectory: URL {
+        #if os(macOS)
+        FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/kaiten-mcp", isDirectory: true)
+        #else
+        let xdgConfig = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
+            ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/.config")
+        return URL(fileURLWithPath: xdgConfig)
+            .appendingPathComponent("kaiten-mcp", isDirectory: true)
+        #endif
+    }
+
+    static var filePath: URL {
+        configDirectory.appendingPathComponent("preferences.json")
+    }
+
+    // MARK: - Load
+
+    /// Load preferences from disk. Returns empty preferences if file doesn't exist.
+    static func load() -> Preferences {
+        let path = filePath
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            return Preferences()
+        }
+        do {
+            let data = try Data(contentsOf: path)
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(Preferences.self, from: data)
+        } catch {
+            log("Warning: failed to parse preferences at \(path.path): \(error)")
+            return Preferences()
+        }
+    }
+
+    // MARK: - Save
+
+    /// Save preferences to disk, creating the directory if needed.
+    func save() throws {
+        let dir = Preferences.configDirectory
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(self)
+        try data.write(to: Preferences.filePath, options: .atomic)
+
+        #if !os(macOS)
+        // Set 0600 permissions on Linux
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: Preferences.filePath.path
+        )
+        #endif
+    }
+}

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -38,6 +38,9 @@ guard ProcessInfo.processInfo.environment["KAITEN_TOKEN"] != nil else {
 let kaiten = try KaitenClient()
 log("KaitenClient initialized successfully")
 
+let preferences = Preferences.load()
+log("Preferences loaded from \(Preferences.filePath.path): boards=\(preferences.boardIds?.description ?? "none"), spaces=\(preferences.spaceIds?.description ?? "none")")
+
 // MARK: - MCP Server
 
 let server = Server(
@@ -184,6 +187,16 @@ let allTools: [Tool] = [
             "required": .array(["id"]),
         ])
     ),
+
+    // Preferences
+    Tool(
+        name: "kaiten_get_preferences",
+        description: "Get current user preferences (configured boards, spaces). Returns the content of the user-level config file.",
+        inputSchema: .object([
+            "type": "object",
+            "properties": .object([:]),
+        ])
+    ),
 ]
 
 // MARK: - Handlers
@@ -243,6 +256,9 @@ await server.withMethodHandler(CallTool.self) { params in
                 let id = try requireInt(params, key: "id")
                 let prop = try await kaiten.getCustomProperty(id: id)
                 return toJSON(prop)
+
+            case "kaiten_get_preferences":
+                return toJSON(preferences)
 
             default:
                 throw ToolError.unknownTool(params.name)


### PR DESCRIPTION
## Summary

Adds a `Preferences` struct that reads/writes a user-level config file:
- **Linux:** `~/.config/kaiten-mcp/preferences.json`
- **macOS:** `~/Library/Application Support/kaiten-mcp/preferences.json`

Users can configure their personal boards and spaces with optional aliases:

```json
{
  "my_spaces": [{"id": 123, "alias": "TMNT"}],
  "my_boards": [{"id": 456, "alias": "Core Sprint"}]
}
```

Also adds `kaiten_get_preferences` tool to inspect current config from MCP clients.

## Changes
- `Sources/kaiten-mcp/Preferences.swift` — new file: config parsing, XDG/macOS paths, load/save
- `Sources/kaiten-mcp/main.swift` — load preferences on startup, add tool definition + handler

## Testing
- `swift build` passes on Linux (VPS)
- CI will verify both platforms

Closes #14