### PR TITLE
Migrate release workflow to matrix strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,50 +8,38 @@ env:
   PRODUCT_NAME: kaiten-mcp
 
 jobs:
-  build-macos:
-    runs-on: macos-26
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: macos-26
+            artifact-name: macos-binary
+            archive-suffix: darwin_arm64
+          - os: ubuntu-24.04
+            artifact-name: linux-x86_64-binary
+            archive-suffix: linux_x86_64
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - name: Read Xcode version
+        if: runner.os == 'macOS'
         id: xcode-version
         run: echo "version=$(<.xcode-version)" >> $GITHUB_OUTPUT
 
       - name: Select Xcode
+        if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ steps.xcode-version.outputs.version }}
 
-      - name: Build release binary
-        id: build
-        run: |
-          swift build -c release --product "$PRODUCT_NAME"
-          echo "bin-path=$(swift build -c release --product "$PRODUCT_NAME" --show-bin-path)" >> $GITHUB_OUTPUT
-
-      - name: Package binary
-        id: package
-        run: |
-          ARCHIVE_NAME="${PRODUCT_NAME}_${GITHUB_REF_NAME}_darwin_arm64.tar.gz"
-          tar -czf "${ARCHIVE_NAME}" -C "${{ steps.build.outputs.bin-path }}" "$PRODUCT_NAME"
-          echo "archive-name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-binary
-          path: ${{ steps.package.outputs.archive-name }}
-
-  build-linux:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup mise
+      - name: Setup mise (Linux)
+        if: runner.os == 'Linux'
         uses: jdx/mise-action@v2
 
-      - name: Setup Swift
+      - name: Setup Swift (Linux)
+        if: runner.os == 'Linux'
         run: mise install swift
 
       - name: Build release binary
@@ -63,18 +51,18 @@ jobs:
       - name: Package binary
         id: package
         run: |
-          ARCHIVE_NAME="${PRODUCT_NAME}_${GITHUB_REF_NAME}_linux_x86_64.tar.gz"
+          ARCHIVE_NAME="${PRODUCT_NAME}_${GITHUB_REF_NAME}_${{ matrix.archive-suffix }}.tar.gz"
           tar -czf "${ARCHIVE_NAME}" -C "${{ steps.build.outputs.bin-path }}" "$PRODUCT_NAME"
           echo "archive-name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: linux-binary
+          name: ${{ matrix.artifact-name }}
           path: ${{ steps.package.outputs.archive-name }}
 
   release:
-    needs: [build-macos, build-linux]
+    needs: [build]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -87,5 +75,4 @@ jobs:
         with:
           generate_release_notes: true
           files: |
-            macos-binary/*.tar.gz
-            linux-binary/*.tar.gz
+            **/*.tar.gz


### PR DESCRIPTION
Replace duplicated build-macos/build-linux jobs with a single matrix job.

Matrix parameters: `os`, `artifact-name`, `archive-suffix`.

Closes #18