### PR TITLE
Add Linux arm64 binary to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
         include:
           - os: macos-26
           - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ jobs:
           - os: ubuntu-24.04
             artifact-name: linux-x86_64-binary
             archive-suffix: linux_x86_64
+          - os: ubuntu-24.04-arm
+            artifact-name: linux-arm64-binary
+            archive-suffix: linux_arm64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Add `ubuntu-24.04-arm` to CI matrix and release matrix.

Release will now produce 3 binaries: `darwin_arm64`, `linux_x86_64`, `linux_arm64`.

Also migrates release.yml to matrix strategy (overlaps with #18).

Closes #24