### PR TITLE
Rename CI workflow to Build and Test, run tests instead of release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 on:
   push:
     branches: [main]
@@ -39,6 +39,3 @@ jobs:
 
       - name: Build
         run: swift build
-
-      - name: Build Release
-        run: swift build -c release


### PR DESCRIPTION
- Rename workflow from `CI` to `Build and Test` (consistent with KaitenSDK)
- Replace `Build Release` step with `Test` (`swift test`)
- Release build already verified by release.yml