### PR TITLE
Fix build: update for KaitenSDK 0.5.0 API changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "0.3.0"
+            from: "0.5.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -39,11 +39,7 @@ guard let kaitenToken = preferences.token else {
     exitWithError("Error: KAITEN_TOKEN not set in config. Run kaiten_set_token tool or edit \(Preferences.filePath.path)")
 }
 
-// Set env vars so KaitenClient picks them up
-setenv("KAITEN_URL", kaitenURL, 1)
-setenv("KAITEN_TOKEN", kaitenToken, 1)
-
-let kaiten = try KaitenClient()
+let kaiten = try KaitenClient(baseURL: kaitenURL, token: kaitenToken)
 log("KaitenClient initialized successfully")
 
 // MARK: - MCP Server
@@ -261,8 +257,8 @@ await server.withMethodHandler(CallTool.self) { params in
             switch params.name {
             case "kaiten_list_cards":
                 let boardId = try requireInt(params, key: "board_id")
-                let cards = try await kaiten.listCards(boardId: boardId)
-                return toJSON(cards)
+                let page = try await kaiten.listCards(boardId: boardId)
+                return toJSON(page.items)
 
             case "kaiten_get_card":
                 let id = try requireInt(params, key: "id")


### PR DESCRIPTION
Build was broken because KaitenSDK removed the parameterless init and env var reading.

Changes:
- `KaitenClient()` → `KaitenClient(baseURL:token:)` (explicit params)
- Remove `setenv` workaround (SDK no longer reads env vars)
- `listCards` now returns `Page<Card>`, extract `.items` for MCP response
- Bump KaitenSDK dependency `0.3.0` → `0.5.0`