### PR TITLE
Unify credentials: read url/token from shared config.json

### DIFF
--- a/Sources/kaiten-mcp/Config.swift
+++ b/Sources/kaiten-mcp/Config.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Shared credentials stored at `~/.config/kaiten-mcp/config.json`.
+/// This file is shared between CLI (KaitenSDK) and MCP.
+struct Config: Codable, Sendable {
+    var url: String?
+    var token: String?
+
+    // MARK: - File path
+
+    static var filePath: URL {
+        Preferences.configDirectory.appendingPathComponent("config.json")
+    }
+
+    // MARK: - Load
+
+    /// Load config from disk. Returns empty config if file doesn't exist.
+    static func load() -> Config {
+        let path = filePath
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            return Config()
+        }
+        do {
+            let data = try Data(contentsOf: path)
+            return try JSONDecoder().decode(Config.self, from: data)
+        } catch {
+            log("Warning: failed to parse config at \(path.path): \(error)")
+            return Config()
+        }
+    }
+
+    // MARK: - Save
+
+    /// Save config to disk, creating the directory if needed. Sets 0600 permissions.
+    func save() throws {
+        let dir = Preferences.configDirectory
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(self)
+        try data.write(to: Config.filePath, options: .atomic)
+
+        // Restrict permissions — file contains secrets
+        #if !os(macOS)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: Config.filePath.path
+        )
+        #endif
+    }
+}

--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// User-level preferences stored at `~/.config/kaiten-mcp/preferences.json`
 /// (Linux) or `~/Library/Application Support/kaiten-mcp/preferences.json` (macOS).
+///
+/// Credentials (url/token) live in `config.json` — shared with CLI.
+/// This file contains only MCP-specific user preferences.
 struct Preferences: Codable, Sendable {
-    var token: String?
-    var url: String?
     var mySpaces: [SpaceRef]?
     var myBoards: [BoardRef]?
 
@@ -80,13 +81,5 @@ struct Preferences: Codable, Sendable {
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let data = try encoder.encode(self)
         try data.write(to: Preferences.filePath, options: .atomic)
-
-        #if !os(macOS)
-        // Set 0600 permissions on Linux
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: Preferences.filePath.path
-        )
-        #endif
     }
 }


### PR DESCRIPTION
Credentials now live in `config.json` (shared with CLI), not `preferences.json`.

- **Config** (`config.json`): `url`, `token` — shared between CLI and MCP
- **Preferences** (`preferences.json`): `myBoards`, `mySpaces` — MCP-only

`kaiten_set_token` now writes to `config.json` with 0600 permissions.

Closes #31