### PR TITLE
Use human-readable job names in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ jobs:
       matrix:
         include:
           - os: macos-26
+            name: macOS ARM64
           - os: ubuntu-24.04
+            name: Linux x86_64
           - os: ubuntu-24.04-arm
+            name: Linux ARM64
+    name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,18 @@ jobs:
       matrix:
         include:
           - os: macos-26
+            name: macOS ARM64
             artifact-name: macos-binary
             archive-suffix: darwin_arm64
           - os: ubuntu-24.04
+            name: Linux x86_64
             artifact-name: linux-x86_64-binary
             archive-suffix: linux_x86_64
           - os: ubuntu-24.04-arm
+            name: Linux ARM64
             artifact-name: linux-arm64-binary
             archive-suffix: linux_arm64
+    name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Jobs now show as `Build (macOS ARM64)`, `Build (Linux x86_64)`, `Build (Linux ARM64)` instead of raw runner names like `build (ubuntu-24.04-arm)`.

Applied to both `ci.yml` and `release.yml`.

Closes #34