### PR TITLE
Update README for config.json credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,24 @@ MCP-сервер для [Kaiten](https://kaiten.ru) — даёт AI-агента
 | `kaiten_get_board` | Доска по ID | `id` |
 | `kaiten_get_board_columns` | Колонки доски | `board_id` |
 | `kaiten_get_board_lanes` | Лейны доски | `board_id` |
-| `kaiten_list_cards` | Карточки на доске | `board_id` |
+| `kaiten_list_cards` | Карточки на доске (пагинация) | `board_id`, `offset?`, `limit?` |
 | `kaiten_get_card` | Карточка по ID | `id` |
 | `kaiten_get_card_members` | Участники карточки | `card_id` |
 | `kaiten_list_custom_properties` | Кастомные свойства | — |
 | `kaiten_get_custom_property` | Кастомное свойство по ID | `id` |
+| `kaiten_configure` | Управление предпочтениями (доски/пространства) | `action`, `ids?`, `id?`, `alias?` |
+| `kaiten_get_preferences` | Текущие предпочтения | — |
+| `kaiten_set_token` | Сохранить URL и токен в конфиг | `url?`, `token?` |
 
 ## Установка
 
 ### Из GitHub Release
 
-Скачайте бинарь для вашей платформы со [страницы релизов](https://github.com/AllDmeat/KaitenMCP/releases).
+Скачайте бинарь для вашей платформы со [страницы релизов](https://github.com/AllDmeat/KaitenMCP/releases):
+
+- `kaiten-mcp_<version>_darwin_arm64.tar.gz` — macOS (Apple Silicon)
+- `kaiten-mcp_<version>_linux_x86_64.tar.gz` — Linux x86_64
+- `kaiten-mcp_<version>_linux_arm64.tar.gz` — Linux ARM64
 
 ### Из исходников
 
@@ -34,14 +41,31 @@ swift build -c release
 
 ## Конфигурация
 
-Создайте `.env` (или экспортируйте переменные иначе):
+Credentials хранятся в `config.json`, пользовательские предпочтения — в `preferences.json`:
+
+| Файл | Путь (Linux) | Путь (macOS) | Содержимое |
+|------|-------------|-------------|------------|
+| `config.json` | `~/.config/kaiten-mcp/config.json` | `~/Library/Application Support/kaiten-mcp/config.json` | `url`, `token` |
+| `preferences.json` | `~/.config/kaiten-mcp/preferences.json` | `~/Library/Application Support/kaiten-mcp/preferences.json` | `myBoards`, `mySpaces` |
+
+`config.json` — общий для MCP и [CLI](https://github.com/AllDmeat/KaitenSDK). Достаточно настроить один раз.
+
+### Вручную
 
 ```bash
-cp env.example .env
-# Отредактируйте .env:
-# KAITEN_URL=https://your-company.kaiten.ru
-# KAITEN_TOKEN=your-api-token
+mkdir -p ~/.config/kaiten-mcp
+cat > ~/.config/kaiten-mcp/config.json << 'EOF'
+{
+  "url": "https://your-company.kaiten.ru/api/latest",
+  "token": "your-api-token"
+}
+EOF
+chmod 600 ~/.config/kaiten-mcp/config.json
 ```
+
+### Через MCP-тул
+
+После подключения сервера вызовите `kaiten_set_token` с параметрами `url` и `token` — файл создастся автоматически.
 
 Токен Kaiten: Настройки профиля → API-токены → Создать.
 
@@ -55,11 +79,7 @@ cp env.example .env
 {
   "mcpServers": {
     "kaiten": {
-      "command": "/path/to/kaiten-mcp",
-      "env": {
-        "KAITEN_URL": "https://your-company.kaiten.ru",
-        "KAITEN_TOKEN": "your-token"
-      }
+      "command": "/path/to/kaiten-mcp"
     }
   }
 }
@@ -74,9 +94,6 @@ mcp:
   servers:
     - name: kaiten
       command: /path/to/kaiten-mcp
-      env:
-        KAITEN_URL: https://your-company.kaiten.ru
-        KAITEN_TOKEN: your-token
 ```
 
 ### Cursor
@@ -86,11 +103,7 @@ Settings → MCP Servers → Add:
 ```json
 {
   "kaiten": {
-    "command": "/path/to/kaiten-mcp",
-    "env": {
-      "KAITEN_URL": "https://your-company.kaiten.ru",
-      "KAITEN_TOKEN": "your-token"
-    }
+    "command": "/path/to/kaiten-mcp"
   }
 }
 ```

--- a/env.example
+++ b/env.example
@@ -1,2 +1,0 @@
-KAITEN_URL=https://your-company.kaiten.ru
-KAITEN_TOKEN=your-token-here


### PR DESCRIPTION
README was outdated — still referenced `.env` files and env vars for credentials.

Updated to reflect current architecture:
- Credentials in `config.json` (shared with CLI)
- Preferences in `preferences.json` (MCP-only)
- All 13 tools listed
- Connection examples without env blocks
- Manual and MCP-tool setup instructions