### PR TITLE
Use single config path ~/.config/kaiten-mcp/ on all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ swift build -c release
 
 Credentials хранятся в `config.json`, пользовательские предпочтения — в `preferences.json`:
 
-| Файл | Путь (Linux) | Путь (macOS) | Содержимое |
-|------|-------------|-------------|------------|
-| `config.json` | `~/.config/kaiten-mcp/config.json` | `~/Library/Application Support/kaiten-mcp/config.json` | `url`, `token` |
-| `preferences.json` | `~/.config/kaiten-mcp/preferences.json` | `~/Library/Application Support/kaiten-mcp/preferences.json` | `myBoards`, `mySpaces` |
+| Файл | Путь | Содержимое |
+|------|------|------------|
+| `config.json` | `~/.config/kaiten-mcp/config.json` | `url`, `token` |
+| `preferences.json` | `~/.config/kaiten-mcp/preferences.json` | `myBoards`, `mySpaces` |
+
+Путь одинаковый на всех платформах (macOS, Linux).
 
 `config.json` — общий для MCP и [CLI](https://github.com/AllDmeat/KaitenSDK). Достаточно настроить один раз.
 

--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -33,18 +33,11 @@ struct Preferences: Codable, Sendable {
 
     // MARK: - File path
 
-    /// Platform-appropriate config directory.
+    /// Config directory — always `~/.config/kaiten-mcp/` on all platforms.
+    /// Matches CLI (KaitenSDK) so credentials in config.json are shared.
     static var configDirectory: URL {
-        #if os(macOS)
-        FileManager.default
-            .homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/kaiten-mcp", isDirectory: true)
-        #else
-        let xdgConfig = ProcessInfo.processInfo.environment["XDG_CONFIG_HOME"]
-            ?? (FileManager.default.homeDirectoryForCurrentUser.path + "/.config")
-        return URL(fileURLWithPath: xdgConfig)
-            .appendingPathComponent("kaiten-mcp", isDirectory: true)
-        #endif
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".config/kaiten-mcp", isDirectory: true)
     }
 
     static var filePath: URL {


### PR DESCRIPTION
MCP was using `~/Library/Application Support/kaiten-mcp/` on macOS but CLI uses `~/.config/kaiten-mcp/`. This broke shared credentials (#31).

Now both tools use `~/.config/kaiten-mcp/` everywhere.

Closes #37