### PR TITLE
Add mise as recommended installation method in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ MCP-сервер для [Kaiten](https://kaiten.ru) — даёт AI-агента
 
 ## Установка
 
+### mise (рекомендуется)
+
+[mise](https://mise.jdx.dev) — менеджер инструментов. Установит нужную версию автоматически:
+
+```bash
+mise use -g ubi:AllDmeat/KaitenMCP
+```
+
 ### Из GitHub Release
 
 Скачайте бинарь для вашей платформы со [страницы релизов](https://github.com/AllDmeat/KaitenMCP/releases):


### PR DESCRIPTION
Add [mise](https://mise.jdx.dev) as the primary way to install KaitenMCP, with GitHub Release and build from source as alternatives.

Closes #39