### PR TITLE
Include url in kaiten_get_preferences response

### DIFF
--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// Combined response for `kaiten_get_preferences` — includes url from config + user preferences.
+/// Token is intentionally excluded.
+struct PreferencesResponse: Codable, Sendable {
+    let url: String?
+    let myBoards: [Preferences.BoardRef]?
+    let mySpaces: [Preferences.SpaceRef]?
+}
+
 /// User-level preferences stored at `~/.config/kaiten-mcp/preferences.json`
 /// (Linux) or `~/Library/Application Support/kaiten-mcp/preferences.json` (macOS).
 ///

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -314,7 +314,12 @@ await server.withMethodHandler(CallTool.self) { params in
                 return toJSON(prop)
 
             case "kaiten_get_preferences":
-                return toJSON(preferences)
+                let response = PreferencesResponse(
+                    url: config.url,
+                    myBoards: preferences.myBoards,
+                    mySpaces: preferences.mySpaces
+                )
+                return toJSON(response)
 
             case "kaiten_set_token":
                 var cfg = Config.load()


### PR DESCRIPTION
`kaiten_get_preferences` now returns `url` from `config.json` alongside boards/spaces. Token is not included.

Closes #41