### PR TITLE
Update KaitenSDK to 0.6.0 and add kaiten_get_card_comments tool

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "0.5.0"
+            from: "0.6.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -107,6 +107,21 @@ let allTools: [Tool] = [
         ])
     ),
 
+    Tool(
+        name: "kaiten_get_card_comments",
+        description: "Get comments on a card",
+        inputSchema: .object([
+            "type": "object",
+            "properties": .object([
+                "card_id": .object([
+                    "type": "integer",
+                    "description": "Card ID",
+                ]),
+            ]),
+            "required": .array(["card_id"]),
+        ])
+    ),
+
     // Spaces & Boards
     Tool(
         name: "kaiten_list_spaces",
@@ -279,6 +294,11 @@ await server.withMethodHandler(CallTool.self) { params in
                 let cardId = try requireInt(params, key: "card_id")
                 let members = try await kaiten.getCardMembers(cardId: cardId)
                 return toJSON(members)
+
+            case "kaiten_get_card_comments":
+                let cardId = try requireInt(params, key: "card_id")
+                let comments = try await kaiten.getCardComments(cardId: cardId)
+                return toJSON(comments)
 
             case "kaiten_list_spaces":
                 let spaces = try await kaiten.listSpaces()


### PR DESCRIPTION
Closes #51

- Bump KaitenSDK from 0.5.0 to 0.6.0 (includes: card comments, nullable fields, custom properties pagination, fromHTTPStatus removal, mise CI, docs)
- Add `kaiten_get_card_comments` MCP tool