### PR TITLE
Add AGENTS.md with English-only language policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# KaitenMCP — Development Guidelines
+
+## Language Policy
+
+**English only.** All content in this repository MUST be in English:
+- Code, comments, documentation
+- Commit messages, PR titles and descriptions
+- Issue titles and descriptions
+- READMEs and any other markdown files
+
+No exceptions.


### PR DESCRIPTION
Creates AGENTS.md with English-only language policy for all repository content.