### PR TITLE
chore: set minimum platforms to iOS 18 and macOS 15

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@ import PackageDescription
 let package = Package(
     name: "KaitenMCP",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15),
+        .iOS(.v18),
+        .macOS(.v15),
     ],
     dependencies: [
         .package(


### PR DESCRIPTION
Match KaitenSDK platform requirements (AllDmeat/KaitenSDK#168).

Closes #56