### PR TITLE
chore: update KaitenSDK to 0.7.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "0.6.0"
+            from: "0.7.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",


### PR DESCRIPTION
Update KaitenSDK dependency from 0.6.0 to 0.7.0.

Changes in SDK 0.7.0:
- Query filters for cards, lanes, custom properties (#102)
- Doc comments on all public API (#123)
- English translation (#163)
- Platform versions: iOS 18 + macOS 15 (#168)
- All schema improvements (#115 subtasks)