### PR TITLE
Default archived=false for kaiten_list_cards

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "0.8.0"
+            from: "0.9.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",


### PR DESCRIPTION
Closes [#69](https://github.com/AllDmeat/kaiten-mcp/issues/69)

By default, `kaiten_list_cards` now returns only non-archived cards. Pass `archived: true` explicitly to include archived cards.

Also bumps SDK dependency to 0.9.0.