### PR TITLE
docs: restructure Usage, add integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ Credentials are stored in `~/.config/kaiten/config.json` (shared with the [CLI](
 }
 ```
 
-You can also set the token later via the `kaiten_set_token` MCP tool after connecting the server.
-
 ### 3. Connect to Your AI Tool
 
 See the **[Integration Guide](docs/integration-guide.md)** for step-by-step instructions for:
@@ -136,7 +134,6 @@ See the **[Integration Guide](docs/integration-guide.md)** for step-by-step inst
 |------|-------------|
 | `kaiten_configure` | Manage preferences (boards/spaces) |
 | `kaiten_get_preferences` | Get current preferences |
-| `kaiten_set_token` | Save URL and token to config |
 
 ## Configuration
 

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -32,11 +32,11 @@ log("Config loaded from \(Config.filePath.path): url=\(config.url != nil ? "set"
 log("Preferences loaded from \(Preferences.filePath.path): boards=\(preferences.boardIds?.description ?? "none"), spaces=\(preferences.spaceIds?.description ?? "none")")
 
 guard let kaitenURL = config.url else {
-    exitWithError("Error: url not set. Run kaiten_set_token tool or edit \(Config.filePath.path)")
+    exitWithError("Error: url not set. Edit \(Config.filePath.path)")
 }
 
 guard let kaitenToken = config.token else {
-    exitWithError("Error: token not set. Run kaiten_set_token tool or edit \(Config.filePath.path)")
+    exitWithError("Error: token not set. Edit \(Config.filePath.path)")
 }
 
 let kaiten = try KaitenClient(baseURL: kaitenURL, token: kaitenToken)
@@ -645,24 +645,6 @@ let allTools: [Tool] = [
             "required": .array(["card_id"]),
         ])
     ),
-
-    Tool(
-        name: "kaiten_set_token",
-        description: "Store Kaiten API token and URL in user config. Token is saved securely with restricted file permissions (0600). Env vars always override config.",
-        inputSchema: .object([
-            "type": "object",
-            "properties": .object([
-                "token": .object([
-                    "type": "string",
-                    "description": "Kaiten API token",
-                ]),
-                "url": .object([
-                    "type": "string",
-                    "description": "Kaiten API base URL (e.g. https://mycompany.kaiten.ru)",
-                ]),
-            ]),
-        ])
-    ),
 ]
 
 // MARK: - Handlers
@@ -879,23 +861,6 @@ await server.withMethodHandler(CallTool.self) { params in
                     myBoards: preferences.myBoards,
                     mySpaces: preferences.mySpaces
                 )
-                return toJSON(response)
-
-            case "kaiten_set_token":
-                var cfg = Config.load()
-                if let token = optionalString(params, key: "token") {
-                    cfg.token = token
-                }
-                if let url = optionalString(params, key: "url") {
-                    cfg.url = url
-                }
-                try cfg.save()
-                // Mask token in response
-                var response = cfg
-                if let t = response.token {
-                    let masked = String(t.prefix(4)) + String(repeating: "*", count: max(0, t.count - 4))
-                    response.token = masked
-                }
                 return toJSON(response)
 
             case "kaiten_configure":

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -6,6 +6,16 @@ How to connect **kaiten-mcp** to popular AI tools.
 
 All examples below use `kaiten-mcp` as the command. If you installed via [mise](https://mise.jdx.dev), it is already in your `PATH`.
 
+## Table of Contents
+
+- [Claude Desktop](#claude-desktop)
+- [Claude Code (CLI)](#claude-code-cli)
+- [GitHub Copilot (VS Code)](#github-copilot-vs-code)
+- [GitHub Copilot CLI](#github-copilot-cli)
+- [Cursor](#cursor)
+- [OpenAI Codex CLI](#openai-codex-cli)
+- [Windsurf](#windsurf)
+
 ---
 
 ## Claude Desktop


### PR DESCRIPTION
## Changes

- **Usage section** restructured into 3 steps: Get Token → Configure → Connect
- **Integration guide** added at `docs/integration-guide.md` with setup instructions for 7 tools:
  Claude Desktop, Claude Code, GitHub Copilot (VS Code), GitHub Copilot CLI, Cursor, OpenAI Codex CLI, Windsurf
- **Configuration section** — removed duplicate config JSON block, added back-reference to Usage
- Consistent `<your-company>` / `<your-api-token>` placeholders