### PR TITLE
fix: rename config directory from kaiten-mcp to kaiten

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ swift build -c release
 
 ### Configuration
 
-Credentials are stored in `~/.config/kaiten-mcp/config.json` (shared with the [CLI](https://github.com/AllDmeat/kaiten-sdk)):
+Credentials are stored in `~/.config/kaiten/config.json` (shared with the [CLI](https://github.com/AllDmeat/kaiten-sdk)):
 
 ```json
 {
@@ -157,7 +157,7 @@ Settings → MCP Servers → Add:
 
 ## Configuration
 
-The config file at `~/.config/kaiten-mcp/config.json` is shared between MCP and [CLI](https://github.com/AllDmeat/kaiten-sdk). You only need to configure it once.
+The config file at `~/.config/kaiten/config.json` is shared between MCP and [CLI](https://github.com/AllDmeat/kaiten-sdk). You only need to configure it once.
 
 ```json
 {
@@ -166,7 +166,7 @@ The config file at `~/.config/kaiten-mcp/config.json` is shared between MCP and 
 }
 ```
 
-User preferences are stored separately in `~/.config/kaiten-mcp/preferences.json`:
+User preferences are stored separately in `~/.config/kaiten/preferences.json`:
 
 ```json
 {

--- a/Sources/kaiten-mcp/Config.swift
+++ b/Sources/kaiten-mcp/Config.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Shared credentials stored at `~/.config/kaiten-mcp/config.json`.
+/// Shared credentials stored at `~/.config/kaiten/config.json`.
 /// This file is shared between CLI (KaitenSDK) and MCP.
 struct Config: Codable, Sendable {
     var url: String?

--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -8,8 +8,8 @@ struct PreferencesResponse: Codable, Sendable {
     let mySpaces: [Preferences.SpaceRef]?
 }
 
-/// User-level preferences stored at `~/.config/kaiten-mcp/preferences.json`
-/// (Linux) or `~/Library/Application Support/kaiten-mcp/preferences.json` (macOS).
+/// User-level preferences stored at `~/.config/kaiten/preferences.json`
+/// (Linux) or `~/Library/Application Support/kaiten/preferences.json` (macOS).
 ///
 /// Credentials (url/token) live in `config.json` — shared with CLI.
 /// This file contains only MCP-specific user preferences.
@@ -41,11 +41,11 @@ struct Preferences: Codable, Sendable {
 
     // MARK: - File path
 
-    /// Config directory — always `~/.config/kaiten-mcp/` on all platforms.
+    /// Config directory — always `~/.config/kaiten/` on all platforms.
     /// Matches CLI (KaitenSDK) so credentials in config.json are shared.
     static var configDirectory: URL {
         let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".config/kaiten-mcp", isDirectory: true)
+        return home.appendingPathComponent(".config/kaiten", isDirectory: true)
     }
 
     static var filePath: URL {


### PR DESCRIPTION
## Summary

Rename the shared config directory from `~/.config/kaiten-mcp/` to `~/.config/kaiten/` (drop the `-mcp` suffix).

Companion to AllDmeat/kaiten-sdk#252 (already merged).

## Changes
- **Sources/kaiten-mcp/Preferences.swift** — update `configDirectory` path and doc comments
- **Sources/kaiten-mcp/Config.swift** — update doc comment
- **README.md** — update all config path references (3 occurrences)

Closes #72