### PR TITLE
Add checklist MCP tools (7 tools)

### DIFF
--- a/.specify/memory/spec.md
+++ b/.specify/memory/spec.md
@@ -68,7 +68,8 @@ An AI agent retrieves information about custom card properties — their definit
 
 - **FR-001**: The server MUST start as a stdio MCP server
 - **FR-002**: The server MUST read KAITEN_URL and KAITEN_TOKEN from environment variables
-- **FR-003**: The server MUST provide a tool for each public KaitenSDK method
+- **FR-003**: The server MUST provide a tool for each public KaitenSDK method. Every public method on `KaitenClient` MUST have a corresponding MCP tool — there MUST be a 1:1 mapping between SDK public API surface and MCP tools. When new methods are added to KaitenSDK, corresponding MCP tools MUST be added before the next release.
+- **FR-003a**: When upgrading the KaitenSDK dependency to a new version, the developer MUST diff the public API surface of `KaitenClient` (all `public func` declarations) between the old and new SDK versions. New methods MUST get corresponding MCP tools, removed methods MUST have their MCP tools deleted, and changed signatures MUST be reflected in tool definitions and handlers. This audit MUST happen as part of every SDK version bump PR.
 - **FR-004**: Each tool MUST return data in JSON format
 - **FR-005**: Each tool MUST return isError=true on SDK errors with an error description
 - **FR-006**: The server MUST crash at startup if KAITEN_URL or KAITEN_TOKEN are missing

--- a/Sources/kaiten-mcp/Config.swift
+++ b/Sources/kaiten-mcp/Config.swift
@@ -3,49 +3,49 @@ import Foundation
 /// Shared credentials stored at `~/.config/kaiten/config.json`.
 /// This file is shared between CLI (KaitenSDK) and MCP.
 struct Config: Codable, Sendable {
-    var url: String?
-    var token: String?
+  var url: String?
+  var token: String?
 
-    // MARK: - File path
+  // MARK: - File path
 
-    static var filePath: URL {
-        Preferences.configDirectory.appendingPathComponent("config.json")
+  static var filePath: URL {
+    Preferences.configDirectory.appendingPathComponent("config.json")
+  }
+
+  // MARK: - Load
+
+  /// Load config from disk. Returns empty config if file doesn't exist.
+  static func load() -> Config {
+    let path = filePath
+    guard FileManager.default.fileExists(atPath: path.path) else {
+      return Config()
     }
-
-    // MARK: - Load
-
-    /// Load config from disk. Returns empty config if file doesn't exist.
-    static func load() -> Config {
-        let path = filePath
-        guard FileManager.default.fileExists(atPath: path.path) else {
-            return Config()
-        }
-        do {
-            let data = try Data(contentsOf: path)
-            return try JSONDecoder().decode(Config.self, from: data)
-        } catch {
-            log("Warning: failed to parse config at \(path.path): \(error)")
-            return Config()
-        }
+    do {
+      let data = try Data(contentsOf: path)
+      return try JSONDecoder().decode(Config.self, from: data)
+    } catch {
+      log("Warning: failed to parse config at \(path.path): \(error)")
+      return Config()
     }
+  }
 
-    // MARK: - Save
+  // MARK: - Save
 
-    /// Save config to disk, creating the directory if needed. Sets 0600 permissions.
-    func save() throws {
-        let dir = Preferences.configDirectory
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
-        try data.write(to: Config.filePath, options: .atomic)
+  /// Save config to disk, creating the directory if needed. Sets 0600 permissions.
+  func save() throws {
+    let dir = Preferences.configDirectory
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(self)
+    try data.write(to: Config.filePath, options: .atomic)
 
-        // Restrict permissions — file contains secrets
-        #if !os(macOS)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: Config.filePath.path
-        )
-        #endif
-    }
+    // Restrict permissions — file contains secrets
+    #if !os(macOS)
+      try FileManager.default.setAttributes(
+        [.posixPermissions: 0o600],
+        ofItemAtPath: Config.filePath.path
+      )
+    #endif
+  }
 }

--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Combined response for `kaiten_get_preferences` — includes url from config + user preferences.
 /// Token is intentionally excluded.
 struct PreferencesResponse: Codable, Sendable {
-    let url: String?
-    let myBoards: [Preferences.BoardRef]?
-    let mySpaces: [Preferences.SpaceRef]?
+  let url: String?
+  let myBoards: [Preferences.BoardRef]?
+  let mySpaces: [Preferences.SpaceRef]?
 }
 
 /// User-level preferences stored at `~/.config/kaiten/preferences.json`
@@ -14,73 +14,73 @@ struct PreferencesResponse: Codable, Sendable {
 /// Credentials (url/token) live in `config.json` — shared with CLI.
 /// This file contains only MCP-specific user preferences.
 struct Preferences: Codable, Sendable {
-    var mySpaces: [SpaceRef]?
-    var myBoards: [BoardRef]?
+  var mySpaces: [SpaceRef]?
+  var myBoards: [BoardRef]?
 
-    struct SpaceRef: Codable, Sendable {
-        let id: Int
-        var alias: String?
+  struct SpaceRef: Codable, Sendable {
+    let id: Int
+    var alias: String?
+  }
+
+  struct BoardRef: Codable, Sendable {
+    let id: Int
+    var alias: String?
+  }
+
+  /// Board IDs from preferences, or `nil` if not configured.
+  var boardIds: [Int]? {
+    guard let boards = myBoards, !boards.isEmpty else { return nil }
+    return boards.map(\.id)
+  }
+
+  /// Space IDs from preferences, or `nil` if not configured.
+  var spaceIds: [Int]? {
+    guard let spaces = mySpaces, !spaces.isEmpty else { return nil }
+    return spaces.map(\.id)
+  }
+
+  // MARK: - File path
+
+  /// Config directory — always `~/.config/kaiten/` on all platforms.
+  /// Matches CLI (KaitenSDK) so credentials in config.json are shared.
+  static var configDirectory: URL {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return home.appendingPathComponent(".config/kaiten", isDirectory: true)
+  }
+
+  static var filePath: URL {
+    configDirectory.appendingPathComponent("preferences.json")
+  }
+
+  // MARK: - Load
+
+  /// Load preferences from disk. Returns empty preferences if file doesn't exist.
+  static func load() -> Preferences {
+    let path = filePath
+    guard FileManager.default.fileExists(atPath: path.path) else {
+      return Preferences()
     }
-
-    struct BoardRef: Codable, Sendable {
-        let id: Int
-        var alias: String?
+    do {
+      let data = try Data(contentsOf: path)
+      let decoder = JSONDecoder()
+      decoder.keyDecodingStrategy = .convertFromSnakeCase
+      return try decoder.decode(Preferences.self, from: data)
+    } catch {
+      log("Warning: failed to parse preferences at \(path.path): \(error)")
+      return Preferences()
     }
+  }
 
-    /// Board IDs from preferences, or `nil` if not configured.
-    var boardIds: [Int]? {
-        guard let boards = myBoards, !boards.isEmpty else { return nil }
-        return boards.map(\.id)
-    }
+  // MARK: - Save
 
-    /// Space IDs from preferences, or `nil` if not configured.
-    var spaceIds: [Int]? {
-        guard let spaces = mySpaces, !spaces.isEmpty else { return nil }
-        return spaces.map(\.id)
-    }
-
-    // MARK: - File path
-
-    /// Config directory — always `~/.config/kaiten/` on all platforms.
-    /// Matches CLI (KaitenSDK) so credentials in config.json are shared.
-    static var configDirectory: URL {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        return home.appendingPathComponent(".config/kaiten", isDirectory: true)
-    }
-
-    static var filePath: URL {
-        configDirectory.appendingPathComponent("preferences.json")
-    }
-
-    // MARK: - Load
-
-    /// Load preferences from disk. Returns empty preferences if file doesn't exist.
-    static func load() -> Preferences {
-        let path = filePath
-        guard FileManager.default.fileExists(atPath: path.path) else {
-            return Preferences()
-        }
-        do {
-            let data = try Data(contentsOf: path)
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            return try decoder.decode(Preferences.self, from: data)
-        } catch {
-            log("Warning: failed to parse preferences at \(path.path): \(error)")
-            return Preferences()
-        }
-    }
-
-    // MARK: - Save
-
-    /// Save preferences to disk, creating the directory if needed.
-    func save() throws {
-        let dir = Preferences.configDirectory
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.keyEncodingStrategy = .convertToSnakeCase
-        let data = try encoder.encode(self)
-        try data.write(to: Preferences.filePath, options: .atomic)
-    }
+  /// Save preferences to disk, creating the directory if needed.
+  func save() throws {
+    let dir = Preferences.configDirectory
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+    let data = try encoder.encode(self)
+    try data.write(to: Preferences.filePath, options: .atomic)
+  }
 }

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -782,6 +782,113 @@ let allTools: [Tool] = [
       "required": .array(["card_id", "link_id"]),
     ])
   ),
+
+  // Checklists
+  Tool(
+    name: "kaiten_create_checklist",
+    description: "Create a new checklist on a card",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "name": .object(["type": "string", "description": "Checklist name"]),
+        "sort_order": .object(["type": "number", "description": "Sort order position"]),
+      ]),
+      "required": .array(["card_id", "name"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_get_checklist",
+    description: "Get a checklist by ID",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+      ]),
+      "required": .array(["card_id", "checklist_id"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_update_checklist",
+    description: "Update a checklist (name, sort order, or move to another card)",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+        "name": .object(["type": "string", "description": "New checklist name"]),
+        "sort_order": .object(["type": "number", "description": "New sort order"]),
+        "move_to_card_id": .object([
+          "type": "integer", "description": "Move checklist to another card",
+        ]),
+      ]),
+      "required": .array(["card_id", "checklist_id"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_remove_checklist",
+    description: "Remove a checklist from a card",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+      ]),
+      "required": .array(["card_id", "checklist_id"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_create_checklist_item",
+    description: "Create a new item in a checklist",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+        "text": .object(["type": "string", "description": "Item text (1-4096 characters)"]),
+        "sort_order": .object(["type": "number", "description": "Sort order (must be > 0)"]),
+        "checked": .object(["type": "boolean", "description": "Checked state"]),
+        "due_date": .object(["type": "string", "description": "Due date (YYYY-MM-DD)"]),
+        "responsible_id": .object(["type": "integer", "description": "Responsible user ID"]),
+      ]),
+      "required": .array(["card_id", "checklist_id", "text"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_update_checklist_item",
+    description: "Update a checklist item",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+        "item_id": .object(["type": "integer", "description": "Checklist item ID"]),
+        "text": .object(["type": "string", "description": "Item text (max 4096 characters)"]),
+        "sort_order": .object(["type": "number", "description": "Sort order (must be > 0)"]),
+        "move_to_checklist_id": .object([
+          "type": "integer", "description": "Move item to another checklist",
+        ]),
+        "checked": .object(["type": "boolean", "description": "Checked state"]),
+        "due_date": .object(["type": "string", "description": "Due date (YYYY-MM-DD)"]),
+        "responsible_id": .object(["type": "integer", "description": "Responsible user ID"]),
+      ]),
+      "required": .array(["card_id", "checklist_id", "item_id"]),
+    ])
+  ),
+  Tool(
+    name: "kaiten_remove_checklist_item",
+    description: "Remove an item from a checklist",
+    inputSchema: .object([
+      "type": "object",
+      "properties": .object([
+        "card_id": .object(["type": "integer", "description": "Card ID"]),
+        "checklist_id": .object(["type": "integer", "description": "Checklist ID"]),
+        "item_id": .object(["type": "integer", "description": "Checklist item ID"]),
+      ]),
+      "required": .array(["card_id", "checklist_id", "item_id"]),
+    ])
+  ),
 ]
 
 // MARK: - Handlers
@@ -1297,6 +1404,75 @@ await server.withMethodHandler(CallTool.self) { params in
         let cardId = try requireInt(params, key: "card_id")
         let linkId = try requireInt(params, key: "link_id")
         let deletedId = try await kaiten.removeExternalLink(cardId: cardId, linkId: linkId)
+        return toJSON(["id": deletedId])
+
+      // Checklists
+      case "kaiten_create_checklist":
+        let cardId = try requireInt(params, key: "card_id")
+        let name = try requireString(params, key: "name")
+        let sortOrder = optionalDouble(params, key: "sort_order")
+        let checklist = try await kaiten.createChecklist(
+          cardId: cardId, name: name, sortOrder: sortOrder)
+        return toJSON(checklist)
+
+      case "kaiten_get_checklist":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let checklist = try await kaiten.getChecklist(cardId: cardId, checklistId: checklistId)
+        return toJSON(checklist)
+
+      case "kaiten_update_checklist":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let name = optionalString(params, key: "name")
+        let sortOrder = optionalDouble(params, key: "sort_order")
+        let moveToCardId = optionalInt(params, key: "move_to_card_id")
+        let checklist = try await kaiten.updateChecklist(
+          cardId: cardId, checklistId: checklistId, name: name, sortOrder: sortOrder,
+          moveToCardId: moveToCardId)
+        return toJSON(checklist)
+
+      case "kaiten_remove_checklist":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let deletedId = try await kaiten.removeChecklist(cardId: cardId, checklistId: checklistId)
+        return toJSON(["id": deletedId])
+
+      case "kaiten_create_checklist_item":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let text = try requireString(params, key: "text")
+        let sortOrder = optionalDouble(params, key: "sort_order")
+        let checked = optionalBool(params, key: "checked")
+        let dueDate = optionalString(params, key: "due_date")
+        let responsibleId = optionalInt(params, key: "responsible_id")
+        let item = try await kaiten.createChecklistItem(
+          cardId: cardId, checklistId: checklistId, text: text, sortOrder: sortOrder,
+          checked: checked, dueDate: dueDate, responsibleId: responsibleId)
+        return toJSON(item)
+
+      case "kaiten_update_checklist_item":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let itemId = try requireInt(params, key: "item_id")
+        let text = optionalString(params, key: "text")
+        let sortOrder = optionalDouble(params, key: "sort_order")
+        let moveToChecklistId = optionalInt(params, key: "move_to_checklist_id")
+        let checked = optionalBool(params, key: "checked")
+        let dueDate = optionalString(params, key: "due_date")
+        let responsibleId = optionalInt(params, key: "responsible_id")
+        let item = try await kaiten.updateChecklistItem(
+          cardId: cardId, checklistId: checklistId, itemId: itemId, text: text,
+          sortOrder: sortOrder, moveToChecklistId: moveToChecklistId, checked: checked,
+          dueDate: dueDate, responsibleId: responsibleId)
+        return toJSON(item)
+
+      case "kaiten_remove_checklist_item":
+        let cardId = try requireInt(params, key: "card_id")
+        let checklistId = try requireInt(params, key: "checklist_id")
+        let itemId = try requireInt(params, key: "item_id")
+        let deletedId = try await kaiten.removeChecklistItem(
+          cardId: cardId, checklistId: checklistId, itemId: itemId)
         return toJSON(["id": deletedId])
 
       default:


### PR DESCRIPTION
## Summary

Add 7 checklist tools that mirror KaitenSDK public API, per FR-003.

### New tools
- `kaiten_create_checklist` — create a checklist on a card
- `kaiten_get_checklist` — get a checklist by ID
- `kaiten_update_checklist` — update name/sort order/move to another card
- `kaiten_remove_checklist` — delete a checklist
- `kaiten_create_checklist_item` — create an item with text, checked, due_date, responsible
- `kaiten_update_checklist_item` — update item fields, move between checklists
- `kaiten_remove_checklist_item` — delete an item

### Spec changes
- FR-003 updated: explicitly requires 1:1 mapping between SDK public methods and MCP tools
- FR-003a added: on every SDK version bump, developer must audit the public API diff and update MCP tools accordingly