### PR TITLE
Upgrade KaitenSDK to 1.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9d2c15b3cbceb2ac48aaf858851ba19b3f55b058e13dad7070950ce513eddc12",
+  "originHash" : "4a2feb0c0bc8db854bd204c612416eee2640d880c0eff4da019804e1264b8797",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AllDmeat/KaitenSDK.git",
       "state" : {
-        "revision" : "2a41612a2a0e454aa22c7adaa9abe8f52ff9a012",
-        "version" : "1.1.0"
+        "revision" : "abcc6ddb159474b059d669ba8f856d8299d94ae5",
+        "version" : "1.2.0"
       }
     },
     {
@@ -49,7 +49,7 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "1.1.0"
+            from: "1.2.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",


### PR DESCRIPTION
## Changes

- Upgrade KaitenSDK dependency from 1.1.0 to 1.2.0
- Fix all breaking changes from SDK 1.2.0 type-safe enums:
  - `CardCondition`, `CardState`, `CardMemberRoleType`, `TextFormatType`
  - `CardPosition`, `ColumnType`, `WipLimitType`, `LaneCondition`
- Update `listCustomPropertySelectValues` default parameters (offset/limit)
- Bump server version to 1.2.0