### PR TITLE
Add kaiten_read_logs tool

### DIFF
--- a/.specify/memory/spec.md
+++ b/.specify/memory/spec.md
@@ -61,6 +61,7 @@ An AI agent retrieves information about custom card properties — their definit
 - What if the token is invalid / expired? → Tool returns isError=true with an unauthorized message
 - What if the Kaiten API is unavailable (timeout, 5xx)? → Tool returns isError=true, retry logic in SDK
 - What if a tool argument is invalid (negative id, missing required parameter)? → Tool returns isError=true with an error description
+- What if the log file does not exist yet? → The log tool returns an empty content string with the resolved log file path
 
 ## Requirements
 
@@ -75,6 +76,7 @@ An AI agent retrieves information about custom card properties — their definit
 - **FR-006**: The server MUST start even if `url` or `token` are missing in config
 - **FR-012**: The server MUST validate `url` and `token` lazily when an API-backed tool is called, and return `isError=true` with an actionable message if credentials are missing
 - **FR-013**: The server MUST provide MCP tool `kaiten_login` that accepts `url` and `token`, validates both values, and saves them to `~/.config/kaiten/config.json`
+- **FR-014**: The server MUST provide MCP tool `kaiten_read_logs` that returns MCP log file path and text content for troubleshooting, with optional tail limiting
 - **FR-007**: The server MUST use KaitenSDK as a dependency, without duplicating business logic
 - **FR-008**: The server MUST build as an executable Swift package (Swift 6.0+, macOS + Linux)
 - **FR-009**: The server MUST have CI via GitHub Actions (build + lint on macOS and Linux)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Or set credentials through MCP after connecting:
 
 - Call `kaiten_login` with `url` and `token`.
 - The server starts even without credentials; API tools validate config lazily and return an error telling you to run `kaiten_login` when credentials are missing.
+- Call `kaiten_read_logs` to get MCP log file path and contents (optionally `tail_lines`).
 
 ### 3. Connect to Your AI Tool
 
@@ -145,6 +146,7 @@ See the **[Integration Guide](docs/integration-guide.md)** for step-by-step inst
 | `kaiten_configure` | Manage preferences (boards/spaces) |
 | `kaiten_get_preferences` | Get current preferences |
 | `kaiten_login` | Save shared API credentials (`url`, `token`) |
+| `kaiten_read_logs` | Read MCP log file path and text content |
 
 ## Configuration
 

--- a/Sources/kaiten-mcp/Preferences.swift
+++ b/Sources/kaiten-mcp/Preferences.swift
@@ -8,6 +8,12 @@ struct PreferencesResponse: Codable, Sendable {
   let mySpaces: [Preferences.SpaceRef]?
 }
 
+/// Response for `kaiten_read_logs`.
+struct LogReadResponse: Codable, Sendable {
+  let path: String
+  let content: String
+}
+
 /// User-level preferences stored at `~/.config/kaiten/preferences.json`
 /// (Linux) or `~/Library/Application Support/kaiten/preferences.json` (macOS).
 ///

--- a/Tests/kaiten-mcpTests/LazyConfigTests.swift
+++ b/Tests/kaiten-mcpTests/LazyConfigTests.swift
@@ -14,4 +14,19 @@ final class LazyConfigTests: XCTestCase {
     func testValidateLoginInputRejectsBlankToken() {
         XCTAssertThrowsError(try validateLoginInput(url: "https://example.kaiten.ru/api/latest", token: " "))
     }
+
+    func testReadLogContentReturnsTailLines() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try "a\nb\nc\n".write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let content = try readLogContent(path: tmp.path, tailLines: 2)
+        XCTAssertEqual(content, "c\n")
+    }
+
+    func testReadLogContentReturnsEmptyForMissingFile() throws {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+        let content = try readLogContent(path: path, tailLines: nil)
+        XCTAssertEqual(content, "")
+    }
 }


### PR DESCRIPTION
## Summary\n- add  MCP tool to return log file path and text content\n- support optional  argument for shorter output\n- update spec and README with new requirement/API entry\n- add tests for log content helper behavior\n\n## Verification\n- swift build --disable-index-store\n- swift test --disable-index-store