### PR TITLE
Resolve remaining actionable open issues

### DIFF
--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -51,7 +51,8 @@ let allTools: [Tool] = [
   // Cards
   Tool(
     name: "kaiten_list_cards",
-    description: "List cards (paginated, max 100 per page). Supports 40+ filter parameters.",
+    description:
+      "List cards (paginated, max 100 per page). Defaults to active (non-archived) cards; set archived=true to include archived cards. Supports 40+ filter parameters.",
     inputSchema: .object([
       "type": "object",
       "properties": .object([
@@ -128,6 +129,7 @@ let allTools: [Tool] = [
         "archived": .object([
           "type": "boolean",
           "description": "Filter by archived status (default: false — only non-archived cards)",
+          "default": .bool(false),
         ]),
         "asap": .object(["type": "boolean", "description": "Filter ASAP cards"]),
         "overdue": .object(["type": "boolean", "description": "Filter overdue cards"]),

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -103,7 +103,7 @@ After adding, open the Command Palette → **MCP: List Servers** → start the s
 
 ## GitHub Copilot CLI
 
-> User-level only — Copilot CLI does not auto-detect project-level MCP configs ([tracking issue](https://github.com/github/copilot-cli/issues/1291)). It does pick up `.vscode/mcp.json` if present.
+> User-level only — Copilot CLI does not auto-detect project-level MCP configs ([tracking issue](https://github.com/github/copilot-cli/issues/1291)).
 
 Create or edit `~/.copilot/mcp-config.json`:
 


### PR DESCRIPTION
## Summary
- update Copilot CLI integration docs to explicitly keep user-level-only guidance
- clarify kaiten_list_cards behavior to default to active non-archived cards
- add explicit schema default for archived=false
- close already-resolved parity issues #86-#95 after verifying tool coverage in code

Closes #101
Closes #103

## Verification
- swift build --disable-index-store
- swift test --disable-index-store
