### PR TITLE
Bump KaitenSDK to 1.3.0 and cut 1.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4a2feb0c0bc8db854bd204c612416eee2640d880c0eff4da019804e1264b8797",
+  "originHash" : "8a465c37420dac93904b10812601e25b03bd6b38a27e3bee59ab78c74dd0aafa",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AllDmeat/KaitenSDK.git",
       "state" : {
-        "revision" : "abcc6ddb159474b059d669ba8f856d8299d94ae5",
-        "version" : "1.2.0"
+        "revision" : "8c59cad123070e19b4ad79de4051a8fdc6a1c0e2",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "1.2.0"
+            from: "1.3.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ See the **[Integration Guide](docs/integration-guide.md)** for step-by-step inst
 | `kaiten_create_space` | Create a space |
 | `kaiten_get_space` | Get a space by ID |
 | `kaiten_update_space` | Update a space |
-| `kaiten_delete_space` | Delete a space |
 
 ### Boards
 
@@ -100,7 +99,6 @@ See the **[Integration Guide](docs/integration-guide.md)** for step-by-step inst
 | `kaiten_get_board` | Get a board by ID |
 | `kaiten_create_board` | Create a board |
 | `kaiten_update_board` | Update a board |
-| `kaiten_delete_board` | Delete a board |
 
 ### Columns
 
@@ -122,7 +120,6 @@ See the **[Integration Guide](docs/integration-guide.md)** for step-by-step inst
 | `kaiten_get_board_lanes` | Get lanes of a board |
 | `kaiten_create_lane` | Create a lane |
 | `kaiten_update_lane` | Update a lane |
-| `kaiten_delete_lane` | Delete a lane |
 
 ### Custom Properties
 

--- a/Sources/kaiten-mcp/Tools/Boards/Boards.swift
+++ b/Sources/kaiten-mcp/Tools/Boards/Boards.swift
@@ -60,16 +60,4 @@ let boardsTools: [Tool] = [
         "required": .array(["space_id", "id"]),
       ])
     ),
-  Tool(
-      name: "kaiten_delete_board",
-      description: "Delete a board",
-      inputSchema: .object([
-        "type": "object",
-        "properties": .object([
-          "space_id": .object(["type": "integer", "description": "Space ID"]),
-          "id": .object(["type": "integer", "description": "Board ID"]),
-        ]),
-        "required": .array(["space_id", "id"]),
-      ])
-    )
 ]

--- a/Sources/kaiten-mcp/Tools/Boards/Lanes.swift
+++ b/Sources/kaiten-mcp/Tools/Boards/Lanes.swift
@@ -53,16 +53,4 @@ let lanesTools: [Tool] = [
         "required": .array(["board_id", "id"]),
       ])
     ),
-  Tool(
-      name: "kaiten_delete_lane",
-      description: "Delete a lane from a board",
-      inputSchema: .object([
-        "type": "object",
-        "properties": .object([
-          "board_id": .object(["type": "integer", "description": "Board ID"]),
-          "id": .object(["type": "integer", "description": "Lane ID"]),
-        ]),
-        "required": .array(["board_id", "id"]),
-      ])
-    )
 ]

--- a/Sources/kaiten-mcp/Tools/Spaces.swift
+++ b/Sources/kaiten-mcp/Tools/Spaces.swift
@@ -49,15 +49,4 @@ let spacesTools: [Tool] = [
         "required": .array(["id"]),
       ])
     ),
-  Tool(
-      name: "kaiten_delete_space",
-      description: "Delete a space by ID",
-      inputSchema: .object([
-        "type": "object",
-        "properties": .object([
-          "id": .object(["type": "integer", "description": "Space ID"])
-        ]),
-        "required": .array(["id"]),
-      ])
-    )
 ]

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -389,11 +389,6 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
         )
         return toJSON(space)
 
-      case "kaiten_delete_space":
-        let id = try requireInt(params, key: "id")
-        let deletedId = try await kaiten.deleteSpace(id: id)
-        return toJSON(["id": deletedId])
-
       // Boards CRUD
       case "kaiten_create_board":
         let spaceId = try requireInt(params, key: "space_id")
@@ -419,12 +414,6 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
           externalId: optionalString(params, key: "external_id")
         )
         return toJSON(board)
-
-      case "kaiten_delete_board":
-        let spaceId = try requireInt(params, key: "space_id")
-        let id = try requireInt(params, key: "id")
-        let deletedId = try await kaiten.deleteBoard(spaceId: spaceId, id: id)
-        return toJSON(["id": deletedId])
 
       // Columns CRUD
       case "kaiten_create_column":
@@ -533,12 +522,6 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
           condition: optionalInt(params, key: "condition").flatMap { LaneCondition(rawValue: $0) }
         )
         return toJSON(lane)
-
-      case "kaiten_delete_lane":
-        let boardId = try requireInt(params, key: "board_id")
-        let id = try requireInt(params, key: "id")
-        let deletedId = try await kaiten.deleteLane(boardId: boardId, id: id)
-        return toJSON(["id": deletedId])
 
       // Card Baselines
       case "kaiten_get_card_baselines":

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -39,7 +39,7 @@ log(
 
 let server = Server(
   name: "KaitenMCP",
-  version: "1.2.0",
+  version: "1.3.0",
   capabilities: .init(
     tools: .init(listChanged: false)
   )


### PR DESCRIPTION
## Summary
- bump KaitenSDK dependency to `1.3.0` and refresh `Package.resolved`
- bump MCP server version to `1.3.0`
- per SDK API diff (1.2.0 -> 1.3.0), remove tools/handlers for removed SDK methods: `kaiten_delete_space`, `kaiten_delete_board`, `kaiten_delete_lane`
- update README API tables accordingly

## Verification
- swift test
- swift build

Closes #108
