### PR TITLE
chore: bump KaitenSDK to 1.6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "99b278ffd37997f4f312f4bb0be55a16dd87acc609306c7e1f0692e1c13fbe66",
+  "originHash" : "4db619e90019190ffd10aaca595a63e6171fccb0e95e44d980f9895aa911de53",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AllDmeat/KaitenSDK.git",
       "state" : {
-        "revision" : "32ea2c9cc6c1e084f9c0b3dd65f42eb964f66111",
-        "version" : "1.4.0"
+        "revision" : "557ee5c944f51c27a96dfeab5231c34bc8238aaf",
+        "version" : "1.6.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "1.4.0"
+            from: "1.6.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -191,37 +191,36 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
 
       case "kaiten_update_card":
         let id = try requireInt(params, key: "id")
-        let card = try await kaiten.updateCard(
-          id: id,
-          title: optionalString(params, key: "title"),
-          description: normalizeOptionalEscapedNewlines(optionalString(params, key: "description")),
-          asap: optionalBool(params, key: "asap"),
-          dueDate: optionalString(params, key: "due_date"),
-          dueDateTimePresent: optionalBool(params, key: "due_date_time_present"),
-          sortOrder: optionalDouble(params, key: "sort_order"),
-          expiresLater: optionalBool(params, key: "expires_later"),
-          sizeText: optionalString(params, key: "size_text"),
-          boardId: optionalInt(params, key: "board_id"),
-          columnId: optionalInt(params, key: "column_id"),
-          laneId: optionalInt(params, key: "lane_id"),
-          ownerId: optionalInt(params, key: "owner_id"),
-          typeId: optionalInt(params, key: "type_id"),
-          serviceId: optionalInt(params, key: "service_id"),
-          blocked: optionalBool(params, key: "blocked"),
-          condition: optionalInt(params, key: "condition").flatMap {
-            CardCondition(rawValue: $0)
-          },
-          externalId: optionalString(params, key: "external_id"),
-          textFormatTypeId: optionalInt(params, key: "text_format_type_id").flatMap {
-            TextFormatType(rawValue: $0)
-          },
-          sdNewComment: optionalBool(params, key: "sd_new_comment"),
-          ownerEmail: optionalString(params, key: "owner_email"),
-          prevCardId: optionalInt(params, key: "prev_card_id"),
-          estimateWorkload: optionalDouble(params, key: "estimate_workload"),
-          plannedStart: optionalString(params, key: "planned_start"),
-          plannedEnd: optionalString(params, key: "planned_end")
-        )
+        var options = CardUpdateOptions()
+        options.title = optionalString(params, key: "title")
+        options.description = normalizeOptionalEscapedNewlines(optionalString(params, key: "description"))
+        options.asap = optionalBool(params, key: "asap")
+        options.dueDate = optionalString(params, key: "due_date")
+        options.dueDateTimePresent = optionalBool(params, key: "due_date_time_present")
+        options.sortOrder = optionalDouble(params, key: "sort_order")
+        options.expiresLater = optionalBool(params, key: "expires_later")
+        options.sizeText = optionalString(params, key: "size_text")
+        options.boardId = optionalInt(params, key: "board_id")
+        options.columnId = optionalInt(params, key: "column_id")
+        options.laneId = optionalInt(params, key: "lane_id")
+        options.ownerId = optionalInt(params, key: "owner_id")
+        options.typeId = optionalInt(params, key: "type_id")
+        options.serviceId = optionalInt(params, key: "service_id")
+        options.blocked = optionalBool(params, key: "blocked")
+        options.condition = optionalInt(params, key: "condition").flatMap {
+          CardCondition(rawValue: $0)
+        }
+        options.externalId = optionalString(params, key: "external_id")
+        options.textFormatTypeId = optionalInt(params, key: "text_format_type_id").flatMap {
+          TextFormatType(rawValue: $0)
+        }
+        options.sdNewComment = optionalBool(params, key: "sd_new_comment")
+        options.ownerEmail = optionalString(params, key: "owner_email")
+        options.prevCardId = optionalInt(params, key: "prev_card_id")
+        options.estimateWorkload = optionalDouble(params, key: "estimate_workload")
+        options.plannedStart = optionalString(params, key: "planned_start")
+        options.plannedEnd = optionalString(params, key: "planned_end")
+        let card = try await kaiten.updateCard(id: id, options)
         return toJSON(card)
 
       case "kaiten_get_card_members":
@@ -237,39 +236,23 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
       case "kaiten_create_card":
         let title = try requireString(params, key: "title")
         let boardId = try requireInt(params, key: "board_id")
-        let columnId = optionalInt(params, key: "column_id")
-        let laneId = optionalInt(params, key: "lane_id")
-        let description = normalizeOptionalEscapedNewlines(optionalString(params, key: "description"))
-        let asap = optionalBool(params, key: "asap")
-        let dueDate = optionalString(params, key: "due_date")
-        let dueDateTimePresent = optionalBool(params, key: "due_date_time_present")
-        let sortOrder = params.arguments?["sort_order"]?.doubleValue
-        let expiresLater = optionalBool(params, key: "expires_later")
-        let sizeText = optionalString(params, key: "size_text")
-        let ownerId = optionalInt(params, key: "owner_id")
-        let responsibleId = optionalInt(params, key: "responsible_id")
-        let ownerEmail = optionalString(params, key: "owner_email")
-        let typeId = optionalInt(params, key: "type_id")
-        let externalId = optionalString(params, key: "external_id")
-        let card = try await kaiten.createCard(
-          title: title,
-          boardId: boardId,
-          columnId: columnId,
-          laneId: laneId,
-          description: description,
-          asap: asap,
-          dueDate: dueDate,
-          dueDateTimePresent: dueDateTimePresent,
-          sortOrder: sortOrder,
-          expiresLater: expiresLater,
-          sizeText: sizeText,
-          ownerId: ownerId,
-          responsibleId: responsibleId,
-          ownerEmail: ownerEmail,
-          position: optionalInt(params, key: "position").flatMap { CardPosition(rawValue: $0) },
-          typeId: typeId,
-          externalId: externalId
-        )
+        var options = CardCreateOptions(title: title, boardId: boardId)
+        options.columnId = optionalInt(params, key: "column_id")
+        options.laneId = optionalInt(params, key: "lane_id")
+        options.description = normalizeOptionalEscapedNewlines(optionalString(params, key: "description"))
+        options.asap = optionalBool(params, key: "asap")
+        options.dueDate = optionalString(params, key: "due_date")
+        options.dueDateTimePresent = optionalBool(params, key: "due_date_time_present")
+        options.sortOrder = optionalDouble(params, key: "sort_order")
+        options.expiresLater = optionalBool(params, key: "expires_later")
+        options.sizeText = optionalString(params, key: "size_text")
+        options.ownerId = optionalInt(params, key: "owner_id")
+        options.responsibleId = optionalInt(params, key: "responsible_id")
+        options.ownerEmail = optionalString(params, key: "owner_email")
+        options.position = optionalInt(params, key: "position").flatMap { CardPosition(rawValue: $0) }
+        options.typeId = optionalInt(params, key: "type_id")
+        options.externalId = optionalString(params, key: "external_id")
+        let card = try await kaiten.createCard(options)
         return toJSON(card)
 
       case "kaiten_create_comment":
@@ -697,7 +680,7 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
       case "kaiten_remove_card_child":
         let cardId = try requireInt(params, key: "card_id")
         let childId = try requireInt(params, key: "child_id")
-        let deletedId = try await kaiten.removeCardChild(cardId: cardId, childId: childId)
+        let deletedId = try await kaiten.removeCardChild(cardId: cardId, childCardId: childId)
         return toJSON(["id": deletedId])
 
       // Users

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -337,7 +337,9 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
           withJSONObject: propsObject.mapValues { jsonValueToAny($0) })
         let properties = try JSONDecoder().decode(
           Components.Schemas.UpdateCardRequest.propertiesPayload.self, from: propsData)
-        let card = try await kaiten.updateCard(id: cardId, properties: properties)
+        var options = CardUpdateOptions()
+        options.properties = properties
+        let card = try await kaiten.updateCard(id: cardId, options)
         return toJSON(card)
 
       // Sprint


### PR DESCRIPTION
## Summary
- Bump KaitenSDK dependency from 1.4.0 to 1.6.0

## Changes in KaitenSDK 1.5.0–1.6.0
- feat: add code generation for ResponseMapping
- fix: rename childId to childCardId in removeCardChild
- fix: CardLocationHistory schema (id string, author object)
- refactor: split KaitenClient into domain extensions
- refactor: use option structs for card create/update
- chore(deps): bump swift-openapi-runtime to 1.11.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)