### PR TITLE
feat: auto-generate version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
+      - name: Generate version
+        run: sh scripts/generate-version.sh "${{ github.ref_name }}"
+
       - name: Build release binary
         id: build
         run: |

--- a/Sources/kaiten-mcp/Version.swift
+++ b/Sources/kaiten-mcp/Version.swift
@@ -1,0 +1,4 @@
+// Generated file. Do not edit manually.
+// Run scripts/generate-version.sh to regenerate.
+
+let kaitenMCPVersion = "dev"

--- a/Sources/kaiten-mcp/main.swift
+++ b/Sources/kaiten-mcp/main.swift
@@ -39,7 +39,7 @@ log(
 
 let server = Server(
   name: "KaitenMCP",
-  version: "1.3.0",
+  version: kaitenMCPVersion,
   capabilities: .init(
     tools: .init(listChanged: false)
   )

--- a/scripts/generate-version.sh
+++ b/scripts/generate-version.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Generate Version.swift with the provided version
+# Usage: ./scripts/generate-version.sh <version>
+# Example: ./scripts/generate-version.sh 1.2.3
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_FILE="$REPO_ROOT/Sources/kaiten-mcp/Version.swift"
+
+if [[ $# -ge 1 && -n "$1" ]]; then
+    VERSION="$1"
+else
+    VERSION="dev"
+fi
+
+cat > "$OUTPUT_FILE" << EOF
+// Generated file. Do not edit manually.
+// Run scripts/generate-version.sh to regenerate.
+
+let kaitenMCPVersion = "$VERSION"
+EOF
+
+echo "Generated $OUTPUT_FILE with version: $VERSION"


### PR DESCRIPTION
## Summary
- Add `scripts/generate-version.sh` to generate `Version.swift` with a version string (defaults to `"dev"`)
- Replace hardcoded version `"1.3.0"` in `main.swift` with the generated `kaitenMCPVersion` constant
- Add "Generate version" step to `release.yml` so CI injects the git tag as the version at build time

## Test plan
- [x] `sh scripts/generate-version.sh 1.5.1` → `Version.swift` contains `"1.5.1"`
- [x] `sh scripts/generate-version.sh` → `Version.swift` contains `"dev"`
- [x] `swift build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)