### PR TITLE
fix: use bash instead of sh to run generate-version.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Generate version
-        run: sh scripts/generate-version.sh "${{ github.ref_name }}"
+        run: bash scripts/generate-version.sh "${{ github.ref_name }}"
 
       - name: Build release binary
         id: build


### PR DESCRIPTION
## Summary
- `scripts/generate-version.sh` uses bash features (`pipefail`, `BASH_SOURCE`, `[[ ]]`) but was called via `sh` in the release workflow
- On Ubuntu runners `sh` → `dash` (POSIX shell), which doesn't support `pipefail`, causing deploy failures
- Changed `sh` → `bash` on line 44 of `release.yml`

## Test plan
- [ ] CI checks pass on this PR
- [ ] Next tag-triggered release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)