### PR TITLE
feat: return summary by default in kaiten_list_cards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "pr@llm-toolkit": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .swiftpm/
 .DS_Store
 .env
-.claude/

--- a/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
@@ -1,8 +1,8 @@
 import KaitenSDK
 
 struct CardSummary: Encodable, Sendable {
-  let id: Int?
-  let title: String?
+  let id: Int
+  let title: String
   let column_id: Int?
   let lane_id: Int?
   let owner_id: Int?
@@ -10,8 +10,8 @@ struct CardSummary: Encodable, Sendable {
   let tag_ids: [Int]?
 
   init(card: Components.Schemas.Card) {
-    self.id = card.id
-    self.title = card.title
+    self.id = card.id ?? 0
+    self.title = card.title ?? ""
     self.column_id = card.column_id
     self.lane_id = card.lane_id
     self.owner_id = card.owner_id

--- a/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
@@ -1,0 +1,21 @@
+import KaitenSDK
+
+struct CardSummary: Encodable, Sendable {
+  let id: Int?
+  let title: String?
+  let column_id: Int?
+  let lane_id: Int?
+  let owner_id: Int?
+  let due_date: String?
+  let tag_ids: [Int]?
+
+  init(card: Components.Schemas.Card) {
+    self.id = card.id
+    self.title = card.title
+    self.column_id = card.column_id
+    self.lane_id = card.lane_id
+    self.owner_id = card.owner_id
+    self.due_date = card.due_date
+    self.tag_ids = card.tag_ids
+  }
+}

--- a/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/CardSummary.swift
@@ -1,8 +1,8 @@
 import KaitenSDK
 
 struct CardSummary: Encodable, Sendable {
-  let id: Int
-  let title: String
+  let id: Int?
+  let title: String?
   let column_id: Int?
   let lane_id: Int?
   let owner_id: Int?
@@ -10,8 +10,8 @@ struct CardSummary: Encodable, Sendable {
   let tag_ids: [Int]?
 
   init(card: Components.Schemas.Card) {
-    self.id = card.id ?? 0
-    self.title = card.title ?? ""
+    self.id = card.id
+    self.title = card.title
     self.column_id = card.column_id
     self.lane_id = card.lane_id
     self.owner_id = card.owner_id

--- a/Sources/kaiten-mcp/Tools/Cards/Cards.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/Cards.swift
@@ -4,7 +4,7 @@ let cardsTools: [Tool] = [
   Tool(
       name: "kaiten_list_cards",
       description:
-        "List cards (paginated, max 100 per page). Defaults to active (non-archived) cards; set archived=true to include archived cards. Supports 40+ filter parameters.",
+        "List cards (paginated, max 100 per page). By default returns summary (id, title, column_id, lane_id, owner_id, due_date, tag_ids); set summary=false for full card objects. Defaults to active (non-archived) cards; set archived=true to include archived cards.",
       inputSchema: .object([
         "type": "object",
         "properties": .object([
@@ -93,6 +93,12 @@ let cardsTools: [Tool] = [
           "order_space_id": .object(["type": "integer", "description": "Space ID for ordering"]),
           "additional_card_fields": .object([
             "type": "string", "description": "Extra fields to include",
+          ]),
+          "summary": .object([
+            "type": "boolean",
+            "description":
+              "When true (default), returns only essential fields (id, title, column_id, lane_id, owner_id, due_date, tag_ids) to save tokens. Set to false for full card objects.",
+            "default": .bool(true),
           ]),
         ]),
       ])

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -182,6 +182,17 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
         let page = try await kaiten.listCards(
           boardId: boardId, columnId: columnId, laneId: laneId, offset: offset, limit: limit,
           filter: filter)
+
+        let summary = optionalBool(params, key: "summary") ?? true
+        if summary {
+          let summaryPage = Page(
+            items: page.items.map { CardSummary(card: $0) },
+            offset: page.offset,
+            limit: page.limit,
+            hasMore: page.hasMore
+          )
+          return toJSON(summaryPage)
+        }
         return toJSON(page)
 
       case "kaiten_get_card":


### PR DESCRIPTION
## Summary
- `kaiten_list_cards` now returns only essential fields (`id`, `title`, `column_id`, `lane_id`, `owner_id`, `due_date`, `tag_ids`) by default, drastically reducing response size
- Added `summary` boolean parameter (default: `true`); set `summary=false` to get full card objects
- Added `CardSummary` struct that maps full card objects to lightweight representations

Closes #119

## Test plan
- [ ] Call `kaiten_list_cards` without `summary` param — should return only summary fields
- [ ] Call `kaiten_list_cards` with `summary=false` — should return full card objects as before
- [ ] Call `kaiten_list_cards` with `summary=true` — should return summary fields
- [ ] Verify pagination metadata (`offset`, `limit`, `hasMore`) is preserved in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)