### PR TITLE
feat: return summary by default in kaiten_get_card

### DIFF
--- a/Sources/kaiten-mcp/Tools/Cards/CardDetailSummary.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/CardDetailSummary.swift
@@ -1,0 +1,51 @@
+import KaitenSDK
+
+struct CardDetailSummary: Encodable, Sendable {
+  let id: Int?
+  let title: String?
+  let description: String?
+  let board_id: Int?
+  let column_id: Int?
+  let lane_id: Int?
+  let state: Int?
+  let condition: Int?
+  let archived: Bool?
+  let blocked: Bool?
+  let asap: Bool?
+  let owner_id: Int?
+  let due_date: String?
+  let created: String?
+  let updated: String?
+  let type_id: Int?
+  let tag_ids: [Int]?
+  let sprint_id: Int?
+  let children_count: Int?
+  let children_done: Int?
+  let parents_count: Int?
+  let size_text: String?
+
+  init(card: Components.Schemas.Card) {
+    self.id = card.id
+    self.title = card.title
+    self.description = card.description
+    self.board_id = card.board_id
+    self.column_id = card.column_id
+    self.lane_id = card.lane_id
+    self.state = card.state
+    self.condition = card.condition
+    self.archived = card.archived
+    self.blocked = card.blocked
+    self.asap = card.asap
+    self.owner_id = card.owner_id
+    self.due_date = card.due_date
+    self.created = card.created
+    self.updated = card.updated
+    self.type_id = card.type_id
+    self.tag_ids = card.tag_ids
+    self.sprint_id = card.sprint_id
+    self.children_count = card.children_count
+    self.children_done = card.children_done
+    self.parents_count = card.parents_count
+    self.size_text = card.size_text
+  }
+}

--- a/Sources/kaiten-mcp/Tools/Cards/Cards.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/Cards.swift
@@ -112,7 +112,13 @@ let cardsTools: [Tool] = [
           "id": .object([
             "type": "integer",
             "description": "Card ID",
-          ])
+          ]),
+          "summary": .object([
+            "type": "boolean",
+            "description":
+              "When true (default), returns only essential fields (id, title, description, board_id, column_id, lane_id, state, condition, archived, blocked, asap, owner_id, due_date, created, updated, type_id, tag_ids, sprint_id, children_count, children_done, parents_count, size_text) to save tokens. Set to false for the full card object.",
+            "default": .bool(true),
+          ]),
         ]),
         "required": .array(["id"]),
       ])

--- a/Sources/kaiten-mcp/Tools/Cards/Cards.swift
+++ b/Sources/kaiten-mcp/Tools/Cards/Cards.swift
@@ -105,7 +105,7 @@ let cardsTools: [Tool] = [
     ),
   Tool(
       name: "kaiten_get_card",
-      description: "Get a single card by ID",
+      description: "Get a single card by ID. Returns a summary with essential fields by default; set summary=false for the full card object.",
       inputSchema: .object([
         "type": "object",
         "properties": .object([

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -198,6 +198,10 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
       case "kaiten_get_card":
         let id = try requireInt(params, key: "id")
         let card = try await kaiten.getCard(id: id)
+        let summary = optionalBool(params, key: "summary") ?? true
+        if summary {
+          return toJSON(CardDetailSummary(card: card))
+        }
         return toJSON(card)
 
       case "kaiten_update_card":


### PR DESCRIPTION
## Summary
- Add `summary` boolean parameter (default: `true`) to `kaiten_get_card` tool
- Create `CardDetailSummary` struct with 22 essential fields (richer than `CardSummary`'s 7 fields used in list)
- When `summary=true` (default), returns only essential fields instead of 60+ to save tokens
- Follows the same pattern established in #120 for `kaiten_list_cards`

## Test plan
- [ ] Build succeeds (`swift build`)
- [ ] `kaiten_get_card` without `summary` param returns ~22 summary fields
- [ ] `kaiten_get_card` with `summary=false` returns full card object
- [ ] `kaiten_get_card` with `summary=true` returns summary fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)