### PR TITLE
Update dependencies and Swift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
@@ -61,7 +61,7 @@ jobs:
           echo "archive-name=${ARCHIVE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ steps.package.outputs.archive-name }}
@@ -73,10 +73,10 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4db619e90019190ffd10aaca595a63e6171fccb0e95e44d980f9895aa911de53",
+  "originHash" : "772fec1b385d5fa6c02c1bda2be1be01de1b163bc13b206a6c8786d1c20d5ec5",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AllDmeat/KaitenSDK.git",
       "state" : {
-        "revision" : "557ee5c944f51c27a96dfeab5231c34bc8238aaf",
-        "version" : "1.6.0"
+        "revision" : "b86d630f3edffd5b093f57efbcbe705e6c2b4fc3",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "772fec1b385d5fa6c02c1bda2be1be01de1b163bc13b206a6c8786d1c20d5ec5",
+  "originHash" : "acea050a2e11ba8fe7c4dfa5cc5b680d3224129a36ab09ad56e8d828401f4666",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
-        "revision" : "ca2a9d90cbe49e09b92f4b6ebd922c03ebea51d0",
-        "version" : "1.3.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattpolzin/OpenAPIKit",
       "state" : {
-        "revision" : "343b2c1793058fcc53c1bd7e2907f8e3a4d640fb",
-        "version" : "3.9.0"
+        "revision" : "57b6318128e3f901c93f4fbf98d1c1464ec168d3",
+        "version" : "6.2.0"
       }
     },
     {
@@ -42,17 +42,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
+      "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -60,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types",
       "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -69,8 +78,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -87,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-generator",
       "state" : {
-        "revision" : "ecf21fdf08d4cf30ca506bb822f5fe580e090efb",
-        "version" : "1.10.4"
+        "revision" : "af9a2a1f5dcfb00a278d4bb29c6d75080932e99e",
+        "version" : "1.13.0"
       }
     },
     {
@@ -96,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-runtime",
       "state" : {
-        "revision" : "7cdf33371bf89b23b9cf4fd3ce8d3c825c28fbe8",
-        "version" : "1.9.0"
+        "revision" : "3d3a8457661daf7fb260ceeb9f0e24e5204ba5fb",
+        "version" : "1.12.0"
       }
     },
     {
@@ -105,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-urlsession",
       "state" : {
-        "revision" : "279aa6b77be6aa842a4bf3c45fa79fa15edf3e07",
-        "version" : "1.2.0"
+        "revision" : "08796d36c99ad2318929bfa1d1e40f82194b65cc",
+        "version" : "1.3.1"
       }
     },
     {
@@ -114,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "c0407a0b52677cb395d824cac2879b963075ba8c",
-        "version" : "0.10.2"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {
@@ -123,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "704705c5c51156ede21172a38654d522ce487074",
+        "version" : "1.8.0"
       }
     },
     {
@@ -132,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
-        "version" : "6.2.1"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.3
 import PackageDescription
 
 let package = Package(
@@ -14,7 +14,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",
-            from: "0.10.0"
+            from: "0.12.1"
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/AllDmeat/KaitenSDK.git",
-            from: "1.6.0"
+            from: "2.3.0"
         ),
         .package(
             url: "https://github.com/modelcontextprotocol/swift-sdk.git",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built on top of [kaiten-sdk](https://github.com/AllDmeat/kaiten-sdk).
 
 ### mise (recommended)
 
-[mise](https://mise.jdx.dev/getting-started.html) — a tool version manager. It will install the required version automatically:
+[mise](https://mise.jdx.dev/getting-started.html) installs the latest release binary for your platform:
 
 ```bash
 mise use github:alldmeat/kaiten-mcp
@@ -23,6 +23,8 @@ mise use github:alldmeat/kaiten-mcp
 Download the binary for your platform from the [releases page](https://github.com/AllDmeat/kaiten-mcp/releases).
 
 ### From Source
+
+Building from source requires Swift 6.3 or newer.
 
 ```bash
 swift build -c release
@@ -164,7 +166,6 @@ User preferences are stored separately in `~/.config/kaiten/preferences.json`:
 
 ## Requirements
 
-- Swift 6.3+
 - macOS 15+ (ARM) / Linux (x86-64, ARM)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ User preferences are stored separately in `~/.config/kaiten/preferences.json`:
 
 ## Requirements
 
-- Swift 6.2+
+- Swift 6.3+
 - macOS 15+ (ARM) / Linux (x86-64, ARM)
 
 ## License

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -636,7 +636,8 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
         let cardId = try requireInt(params, key: "card_id")
         let userId = try requireInt(params, key: "user_id")
         let typeValue = try requireInt(params, key: "type")
-        guard let roleType = CardMemberRoleType(rawValue: typeValue) else {
+        let roleType = CardMemberRoleType(rawValue: typeValue)
+        guard CardMemberRoleType.allCases.contains(roleType) else {
           throw ToolError.invalidType(key: "type", expected: "1 (member) or 2 (responsible)")
         }
         let role = try await kaiten.updateCardMemberRole(

--- a/Sources/kaiten-mcp/Tools/ToolHandler.swift
+++ b/Sources/kaiten-mcp/Tools/ToolHandler.swift
@@ -783,16 +783,18 @@ func handleToolCall(_ params: CallTool.Parameters) async -> CallTool.Result {
       }
     }()
     log("Tool call succeeded: \(params.name) in \(elapsedMilliseconds(since: startedAt))ms")
-    return .init(content: [.text(json)], isError: false)
+    return .init(content: [.text(text: json, annotations: nil, _meta: nil)], isError: false)
   } catch let error as ToolError {
     log(
       "Tool call failed: \(params.name) in \(elapsedMilliseconds(since: startedAt))ms, error=\(error.description)"
     )
-    return .init(content: [.text(error.description)], isError: true)
+    return .init(
+      content: [.text(text: error.description, annotations: nil, _meta: nil)], isError: true)
   } catch {
     log(
       "Tool call failed: \(params.name) in \(elapsedMilliseconds(since: startedAt))ms, unexpected=\(error)"
     )
-    return .init(content: [.text("Error: \(error)")], isError: true)
+    return .init(
+      content: [.text(text: "Error: \(error)", annotations: nil, _meta: nil)], isError: true)
   }
 }

--- a/Tests/kaiten-mcpTests/ToolsStructureTests.swift
+++ b/Tests/kaiten-mcpTests/ToolsStructureTests.swift
@@ -8,7 +8,7 @@ final class ToolsStructureTests: XCTestCase {
       .deletingLastPathComponent()
       .deletingLastPathComponent()
     let mainFile = sourceRoot.appendingPathComponent("Sources/kaiten-mcp/main.swift")
-    let content = try String(contentsOf: mainFile)
+    let content = try String(contentsOf: mainFile, encoding: .utf8)
     let lineCount = content.split(separator: "\n", omittingEmptySubsequences: false).count
     XCTAssertLessThan(
       lineCount,

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 experimental = true
 
 [tools]
-swift = "6.2.3"
+swift = "6.3.3"


### PR DESCRIPTION
## What changed

- updated `KaitenSDK` from 1.6.0 to 2.3.0
- updated `modelcontextprotocol/swift-sdk` from 0.10.x to 0.12.1
- updated every transitive package selected by SwiftPM
- updated Swift from 6.2.3 to 6.3.3 and the package tools version from 6.2 to 6.3
- migrated deprecated MCP text content calls to the current API
- adapted card member role validation to the new `KaitenSDK` enum behavior
- updated the documented Swift requirement

## Why

The package was pinned to old SDK and toolchain versions. Updating both direct dependencies also moves the OpenAPI, NIO, logging, collections, and system packages to their latest compatible releases.

`KaitenSDK` now keeps unknown card member role values in an `.unknown` case instead of returning `nil`. The MCP server still accepts only the two documented role values, so it validates the constructed enum against `allCases`.

## Impact

The server builds with Swift 6.3.3 and uses the latest available dependency graph. Existing MCP tool behavior stays the same.

## Checks

- `mise exec -- swift package update` — everything is already up to date
- `mise exec -- swift test` — 11 tests passed on Swift 6.3.3
- `git diff --check`
